### PR TITLE
refactor: 迁移 LSP 配置到 Neovim 0.11+ 原生 vim.lsp.config API

### DIFF
--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -82,13 +82,11 @@ M.on_attach = function(client, bufnr)
 	lsp_highlight_document(client)
 end
 
-local capabilities = vim.lsp.protocol.make_client_capabilities()
+M.capabilities = vim.lsp.protocol.make_client_capabilities()
 
 local status_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
-if not status_ok then
-	return
+if status_ok then
+	M.capabilities = cmp_nvim_lsp.default_capabilities(M.capabilities)
 end
-
-M.capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
 
 return M

--- a/lua/user/lsp/init.lua
+++ b/lua/user/lsp/init.lua
@@ -1,8 +1,3 @@
-local status_ok, _ = pcall(require, "lspconfig")
-if not status_ok then
-	return
-end
-
+-- LSP Configuration (using Neovim 0.11+ vim.lsp.config API)
 require("user.lsp.configs")
 require("user.lsp.handlers").setup()
---require "user.lsp.null-ls"


### PR DESCRIPTION
将 LSP 服务器配置从 nvim-lspconfig 迁移到 Neovim 0.11+ 引入的 vim.lsp.config 原生 API，减少依赖并提升性能。

主要变更：
- configs.lua: 使用 vim.lsp.config() 替代 lspconfig[server].setup()
- handlers.lua: 修复 capabilities 模块导出，确保 cmp_nvim_lsp 正确集成
- init.lua: 移除 lspconfig 依赖检查，简化初始化流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration update

## Changes Made
- 
- 
- 

## Testing
- [ ] Tested locally
- [ ] No breaking changes
- [ ] All existing functionality works

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.
